### PR TITLE
Fix bugs for date validity check

### DIFF
--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -28,7 +28,7 @@ public class AddCommand extends Command {
     private static final String UNIT_SEPARATOR = "-u";
 
     private static final String INVALID_DATE_MESSAGE =
-            "Please input a valid  date :<";
+            "Please input a valid date :<";
     private static final String EXPIRY_DATE_MESSAGE =
             "Please do not add an expired product :<";
 
@@ -61,8 +61,12 @@ public class AddCommand extends Command {
 
         try {
             LocalDate expiryDate = LocalDate.parse(date, formatter);
-            boolean isValid = isValidDate(expiryDate);
+            boolean isValid = isValid(date);
+            boolean isExpired = isTheDateAfterCurrentDate(expiryDate);
             if (!isValid) {
+                return new CommandResult(INVALID_DATE_MESSAGE);
+            }
+            if (!isExpired) {
                 return new CommandResult(EXPIRY_DATE_MESSAGE);
             }
             assert !name.trim().isEmpty() : "Expected non-empty string for name";
@@ -230,10 +234,24 @@ public class AddCommand extends Command {
      * @param expiryDate the date
      * @return isValid whether the date is valid
      */
-    public boolean isValidDate(LocalDate expiryDate) {
+    public boolean isTheDateAfterCurrentDate(LocalDate expiryDate) {
         LocalDate currentDate = LocalDate.now();
         boolean isValid = expiryDate.isAfter(currentDate);
         return isValid;
+    }
+
+    public boolean isValid(String date) {
+        String[] splitString = date.split("/", 3);
+        String d = splitString[0];
+        String m = splitString[1];
+        String y = splitString[2];
+
+        if (Integer.parseInt(y) % 4 != 0 && m.equals("02")) {
+            if (d.equals("29")) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -50,7 +50,7 @@ class AddCommandTest {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         LocalDate expiryDate = LocalDate.parse(date, formatter);
         boolean expected = true;
-        assertEquals(expected, addFood.isValidDate(expiryDate));
+        assertEquals(expected, addFood.isTheDateAfterCurrentDate(expiryDate));
     }
 
     @Test
@@ -61,7 +61,7 @@ class AddCommandTest {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         LocalDate expiryDate = LocalDate.parse(date, formatter);
         boolean expected = false;
-        assertEquals(expected, addFood.isValidDate(expiryDate));
+        assertEquals(expected, addFood.isTheDateAfterCurrentDate(expiryDate));
     }
 
 }


### PR DESCRIPTION
After updating the code, the add command is able to handle `-e 29/02/2027` special date, which cannot appear in a non-leap year.