### PR TITLE
Update quantity bug

### DIFF
--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -10,8 +10,10 @@ public class FindCommand extends Command {
     String term;
     String[] flags;
 
+    private static final String FLAG_SEPARATOR = "--";
+
     public FindCommand(String arguments) {
-        String[] details = arguments.split("-");
+        String[] details = arguments.split(FLAG_SEPARATOR);
         this.term = details[0];
         this.flags = Arrays.copyOfRange(details, 1, details.length);
     }

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -7,10 +7,11 @@ import java.util.Arrays;
 
 public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
-    String term;
-    String[] flags;
 
     private static final String FLAG_SEPARATOR = "--";
+
+    String term;
+    String[] flags;
 
     public FindCommand(String arguments) {
         String[] details = arguments.split(FLAG_SEPARATOR);

--- a/src/main/java/seedu/duke/commands/UpdateCommand.java
+++ b/src/main/java/seedu/duke/commands/UpdateCommand.java
@@ -11,10 +11,9 @@ import java.util.Arrays;
 
 public class UpdateCommand extends Command{
     public static final String COMMAND_WORD = "update";
+    private static final String FLAG_SEPARATOR = "--";
     String index;
     String[] flags;
-
-    private static final String FLAG_SEPARATOR = "--";
 
     public UpdateCommand(String arguments) {
         String[] details = arguments.split(FLAG_SEPARATOR);

--- a/src/main/java/seedu/duke/commands/UpdateCommand.java
+++ b/src/main/java/seedu/duke/commands/UpdateCommand.java
@@ -14,8 +14,10 @@ public class UpdateCommand extends Command{
     String index;
     String[] flags;
 
+    private static final String FLAG_SEPARATOR = "--";
+
     public UpdateCommand(String arguments) {
-        String[] details = arguments.split("-");
+        String[] details = arguments.split(FLAG_SEPARATOR);
         this.index = details[0];
         this.flags = Arrays.copyOfRange(details, 1, details.length);
     }
@@ -43,6 +45,9 @@ public class UpdateCommand extends Command{
                     currentFood.setExpiryDate(flagValue);
                     break;
                 case "q":
+                    if (currentFood.getQuantity() == 0) {
+                        throw new DukeException("Can't set quantity with no unit provided");
+                    }
                     currentFood.setQuantity(Double.parseDouble(flagValue));
                     break;
                 case "u":
@@ -54,7 +59,7 @@ public class UpdateCommand extends Command{
                 default:
                     throw new InvalidFlagException(flagName);
                 }
-            } catch (InvalidFlagException e) {
+            } catch (DukeException e) {
                 throw e;
             } catch (Exception e) {
                 throw new IllegalValueException("Illegal value for the flag " + flagName);


### PR DESCRIPTION
- Fix the bug for an `update` command: if no unit specified for the food, throw an exception with message

- Replace `-` with `separator` and remove magic literal