### PR TITLE
Fix: flag handling for multi word flag values

### DIFF
--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -62,7 +62,7 @@ public class FindCommand extends Command {
 
             if (hasTerm) {
                 for (String flag : flags) {
-                    String[] flagParts = flag.trim().split(" ");;
+                    String[] flagParts = flag.trim().split(" ", 2);;
 
                     String flagName = flagParts[0];
 

--- a/src/main/java/seedu/duke/commands/UpdateCommand.java
+++ b/src/main/java/seedu/duke/commands/UpdateCommand.java
@@ -95,7 +95,7 @@ public class UpdateCommand extends Command{
         Food currentFood = foodList.getFood(index);
 
         for (String flag: flags) {
-            String[] flagParts = flag.trim().split(" ");
+            String[] flagParts = flag.trim().split(" ", 2);
 
             if (flagParts.length == 1) {
                 String invalidFlagName = flagParts[0];


### PR DESCRIPTION
By limiting `split`, we can accept multi-word flag values with spaces inside now